### PR TITLE
supressed invite reqiest error message

### DIFF
--- a/webui/src/services/okrservice.js
+++ b/webui/src/services/okrservice.js
@@ -239,7 +239,9 @@ export default class OkrService {
                     .then(data => {})
                     .catch(errHandler);
             })
-            .catch(errHandler); 
+            // Hide sharing error since most users shared the notebook using work-around.
+            // TODO : return back when OneNote API sharing functionality will be used.
+            .catch(() => {});
     }
 
     getSection(subjectId, readonlyMode, dataHandler, errHandler) {


### PR DESCRIPTION
Some people shared their notebooks using "good" machines but still use their "bad" machines to edit goals. I think it's good to hide the invite request error temporarily.