### PR TITLE
Clean objectives list in the case access is denied for current user

### DIFF
--- a/webui/src/services/onedrivehelper.js
+++ b/webui/src/services/onedrivehelper.js
@@ -76,3 +76,4 @@ export default class OneDriveHelper {
             .catch(errHandler);
     }
 }
+

--- a/webui/src/store/modules/okr.js
+++ b/webui/src/store/modules/okr.js
@@ -236,6 +236,10 @@ export default {
                         commit('MARK_ONEDRIVE_LICENSE_ERROR');
                         // No objectives available for such users
                         commit('CLEAR_OBJECTIVES');
+                    } else if (err.statusCode === 403) {
+                        // Authorization_RequestDenied is the marker that goals are not accessible for current user.
+                        // In this case we will just clean current objectives list.
+                        commit('CLEAR_OBJECTIVES');
                     } else {
                         commit('OBJECTIVES_FAILED', err);
                     }


### PR DESCRIPTION
Looks like Microsoft has changed onedrive API and now it returns 403 (Access Denied).
This change is simply about to clean current objectives list in the case of such error.